### PR TITLE
Empty default DockerCredentials make cfn-init fail

### DIFF
--- a/mesos-master.json
+++ b/mesos-master.json
@@ -62,7 +62,7 @@
     "DockerCredentials" : {
       "Description" : "JSON string to be saved as .dockercfg",
       "Type" : "String",
-      "Default" : ""
+      "Default" : "{}"
     },
     "LogstashConfig" : {
       "Description" : "(optional) Config string for Logstash",

--- a/mesos-slave.json
+++ b/mesos-slave.json
@@ -43,7 +43,7 @@
     "DockerCredentials" : {
       "Description" : "JSON string to be saved as .dockercfg",
       "Type" : "String",
-      "Default" : ""
+      "Default" : "{}"
     },
     "LogstashConfig" : {
       "Description" : "(optional) Config string for Logstash (to read task logs, you can use 'input { file { path => \"/tmp/mesos/slaves/*/frameworks/*/executors/*/runs/latest/stdout\" }')",


### PR DESCRIPTION
Cfn-init will wail on the nodes with:
"Error encountered during build of config: File specified without source
or content"
