### PR TITLE
Pass instance type to master template

### DIFF
--- a/mesos.json
+++ b/mesos.json
@@ -159,6 +159,7 @@
         "TimeoutInMinutes" : "15",
         "Parameters" : {
           "InstanceAmi" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI"] },
+          "InstanceType" : { "Ref" : "MasterInstanceType" },
           "KeyName" : { "Ref" : "KeyName" },
           "ClusterId" : { "Ref" : "ClusterId" },
           "ClusterSize" : { "Ref" : "MasterInstanceCount" },


### PR DESCRIPTION
Master instance type parameter in mesos.json is not propagating to master template.
