### PR TITLE
fix error when not specifying DockerCredentials parameter

### DIFF
--- a/mesos.json
+++ b/mesos.json
@@ -92,7 +92,7 @@
     "DockerCredentials" : {
       "Description" : "JSON string to be saved as .dockercfg",
       "Type" : "String",
-      "Default" : ""
+      "Default" : "{}"
     },
     "MarathonDockerImage" : {
       "Description" : "The Marathon Docker image (format: 'registry:port/repository:version')",


### PR DESCRIPTION
The previous fix for this only modified the default value in the sub-templates, but I was still getting an error when spinning up the entire stack using the main template, since the value is passed into the sub-templates, rather than their default used.
